### PR TITLE
remove heavier font and add . to sentence 

### DIFF
--- a/src/views/GPfooter/CustomGPfooter.js
+++ b/src/views/GPfooter/CustomGPfooter.js
@@ -51,11 +51,9 @@ export default function CustomGPfooter() {
                   </a>
                   {/* <br /> */}
                   <p>
-                    <strong>
-                      We translate current research into creative
-                      interdisciplinary lessons for grades 5+ that are{" "}
-                      <i>free for everyone</i>
-                    </strong>
+                    We translate current research into creative
+                    interdisciplinary lessons for grades 5+ that are{" "}
+                    <i>free for everyone</i>.
                   </p>
                   <ul className={classes.socialButtons}>
                     <li>
@@ -118,10 +116,8 @@ export default function CustomGPfooter() {
                 <GridItem xs={12} sm={3} md={3}>
                   <h5>Join Our Mailing List</h5>
                   <p>
-                    <strong>
-                      Get updates and early access to our latest free lessons
-                      and learning tools.
-                    </strong>
+                    Get updates and early access to our latest free lessons and
+                    learning tools.
                   </p>
                   <form>
                     <Button


### PR DESCRIPTION
This is a partial fix for Matt's request. Waiting for font confirmation after upon other page inspection the default font looks to be `font-family: "Montserrat", "Helvetica", "Arial", sans-serif;`
and only some places have 
`font-family: "Cormorant Garamond", "Times New Roman", serif;`