### PR TITLE
Fix/safari anchor links

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "react-slick": "0.26.1",
     "react-snap": "^1.23.0",
     "react-swipeable-views": "0.13.9",
-    "react-tagsinput": "3.19.0",
-    "showdown": "^1.9.1"
+    "react-tagsinput": "3.19.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/CustomMarkdownView/index.js
+++ b/src/components/CustomMarkdownView/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import MarkdownView from "react-showdown";
+import AnchorLink from 'react-anchor-link-smooth-scroll';
+
+const components = {
+  AnchorLink (props) {
+    return <AnchorLink offset="125px" {...props} />
+  }
+}
+
+const CustomMarkdownView = ({
+  markdown
+}) => {
+  return <MarkdownView markdown={markdown} components={{...components}} />
+}
+
+export default CustomMarkdownView

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -1,20 +1,17 @@
 import React from "react";
-import showdown from "showdown";
 import PropTypes from "prop-types";
 
-import "./styles.scss";
+import CustomMarkdownView from "components/CustomMarkdownView";
 
-const converter = new showdown.Converter();
+import "./styles.scss";
 
 const RichText = ({ content, className = "" }) => {
   if (!content) return null;
 
-  let __html = converter.makeHtml(content);
-
   return (
-    <div
+    <CustomMarkdownView
       className={"RichText " + className}
-      dangerouslySetInnerHTML={{ __html }}
+      markdown={content}
     />
   );
 };


### PR DESCRIPTION
- replace `showdown` with `react-showdown`
- enable use of `<AnchorLink />` components inline in markdown