### PR TITLE
Feat/default links to new tab

### DIFF
--- a/src/components/CustomMarkdownView/index.js
+++ b/src/components/CustomMarkdownView/index.js
@@ -20,9 +20,14 @@ const components = {
 }
 
 const CustomMarkdownView = ({
-  markdown
+  markdown,
+  ...passThruProps
 }) => {
-  return <MarkdownView markdown={markdown} components={{...components}} />
+  return <MarkdownView
+    {...passThruProps}
+    markdown={markdown}
+    components={{...components}}
+  />
 }
 
 export default CustomMarkdownView


### PR DESCRIPTION
- all standard markdown links (`[text](url)`) will open in a new tab unless they are on the base galacticpolymath.com domain (subdomains will open in a new tab)
- fixed image width issue in markdown fields